### PR TITLE
Fixing typo in pkg(adproclus)

### DIFF
--- a/Cluster.md
+++ b/Cluster.md
@@ -310,7 +310,7 @@ Leisch who also served as its first maintainer.
     local density value. The cluster centroids of this non-iterative
     procedure can be selected using an interactive or automatic
     selection mode.
--   Package `r pkg("adproclust")` provides the Additive Profile
+-   Package `r pkg("adproclus")` provides the Additive Profile
 	Clustering (ADPROCLUS) method as well as the low-dimensional
 	ADPROCLUS method, which allows for simultaneous dimension
 	reduction, to obtain overlapping clustering models for


### PR DESCRIPTION
Was "adproclust" instead of "adproclus" causing the link to the package CRAN page to be broken